### PR TITLE
Bump to ed25519-hd-key 1.1.2

### DIFF
--- a/README.md
+++ b/README.md
@@ -27,6 +27,9 @@ In this example we will get the public key for a Lisk address. The function shou
 
 > m / purpose' / coin_type' / account' / change' / address_index'
 
+**NOTE**: Every Lisk wallet that provides hardware wallet integration are simply using the following derivation:
+
+> m / purpose' / coin_type' / account'
 
 **Usage**
 
@@ -34,16 +37,20 @@ In this example we will get the public key for a Lisk address. The function shou
 const { getPublicKey } = require('lisk-hd-key');
 
 const bip39 = require('bip39');
-const path = "m/44'/134'/0'/0'/0'";
+const path = "m/44'/134'/0'";
 
-// sunny settle rent arrive coast emotion twice outdoor erupt scale once reason
-const seed = bip39.generateMnemonic();
+const doPubKeyTest = async () => {
+    // sunny settle rent arrive coast emotion twice outdoor erupt scale once reason
+    const seed = bip39.generateMnemonic();
+    
+    // 18e48e187b700d4596983f2efaf64f63c31ff13b4537abea1157bdf45c1fc9e5c5d8a817048616d24dcd0b7ae638df786cec2dc0749f6847724905988ae56b0e
+    const hexSeed = await bip39.mnemonicToSeed(seed);
+    
+    // <Buffer e7 7d a0 2e 45 ec 11 a3 69 70 58 2e ad 68 11 e2 78 79 7a 14 f3 15 a0 a6 9a 3e fe 9f 6c 76 24 b6>
+    const publicKey = getPublicKey(path, hexSeed);
+}
 
-// 18e48e187b700d4596983f2efaf64f63c31ff13b4537abea1157bdf45c1fc9e5c5d8a817048616d24dcd0b7ae638df786cec2dc0749f6847724905988ae56b0e
-const hexSeed = bip39.mnemonicToSeedHex(seed);
-
-// <Buffer e7 7d a0 2e 45 ec 11 a3 69 70 58 2e ad 68 11 e2 78 79 7a 14 f3 15 a0 a6 9a 3e fe 9f 6c 76 24 b6>
-const publicKey = getPublicKey(path, hexSeed);
+doPubKeyTest();
 ```
 <br>
 
@@ -57,6 +64,10 @@ In this example we will sign a transaction. Signing a transaction means that nob
 
 > m / purpose' / coin_type' / account' / change' / address_index'
 
+**NOTE**: Every Lisk wallet that provides hardware wallet integration are simply using the following derivation:
+
+> m / purpose' / coin_type' / account'
+
 
 `transaction`
 This parameter is a [Lisk transaction object](https://lisk.io/documentation/the-lisk-protocol/transactions). It can have the same properties as a transaction described in the given url.
@@ -67,7 +78,7 @@ This parameter is a [Lisk transaction object](https://lisk.io/documentation/the-
 const { signTransaction } = require('lisk-hd-key');
 
 const bip39 = require('bip39');
-const path = "m/44'/134'/0'/0'/0'";
+const path = "m/44'/134'/0'";
 
 const unsignedTransaction = {
    "amount": "25",
@@ -80,28 +91,32 @@ const unsignedTransaction = {
     }
 };
 
-// sunny settle rent arrive coast emotion twice outdoor erupt scale once reason
-const seed = bip39.generateMnemonic();
+const doSignTest = async () => {
+    // sunny settle rent arrive coast emotion twice outdoor erupt scale once reason
+    const seed = bip39.generateMnemonic();
 
-// 18e48e187b700d4596983f2efaf64f63c31ff13b4537abea1157bdf45c1fc9e5c5d8a817048616d24dcd0b7ae638df786cec2dc0749f6847724905988ae56b0e
-const hexSeed = bip39.mnemonicToSeedHex(seed);
+    // 18e48e187b700d4596983f2efaf64f63c31ff13b4537abea1157bdf45c1fc9e5c5d8a817048616d24dcd0b7ae638df786cec2dc0749f6847724905988ae56b0e
+    const hexSeed = await bip39.mnemonicToSeed(seed);
 
-/*
-{
-  "amount": "25",
-  "recipientId": "1L",
-  "timestamp": 1525977822,
-  "type": 0,
-  "fee": "20000000",
-  "asset": {
-    "data": "Custom message to show i have signed the transaction."
-  },
-  "senderPublicKey": "e77da02e45ec11a36970582ead6811e278797a14f315a0a69a3efe9f6c7624b6",
-  "signature": "f6fb203848affe7c88f3b68bfefa012b9eb37581a34eb2b5b930d5045ab3575aab6ce9683bf16f85f63453481576ac08efd39f2b194121639b03c8b4aaf3060e",
-  "id": "403666780544575699"
+    /*
+    {
+    "amount": "25",
+    "recipientId": "1L",
+    "timestamp": 1525977822,
+    "type": 0,
+    "fee": "20000000",
+    "asset": {
+        "data": "Custom message to show i have signed the transaction."
+    },
+    "senderPublicKey": "e77da02e45ec11a36970582ead6811e278797a14f315a0a69a3efe9f6c7624b6",
+    "signature": "f6fb203848affe7c88f3b68bfefa012b9eb37581a34eb2b5b930d5045ab3575aab6ce9683bf16f85f63453481576ac08efd39f2b194121639b03c8b4aaf3060e",
+    "id": "403666780544575699"
+    }
+    */
+    const signedTransaction = signTransaction(hexSeed, path, unsignedTransaction)
 }
-*/
-const signedTransaction = signTransaction(hexSeed, path, unsignedTransaction)
+
+doSignTest();
 ```
 
 Tests

--- a/package.json
+++ b/package.json
@@ -59,7 +59,7 @@
   "dependencies": {
     "@types/node": "^10.0.3",
     "coveralls": "^3.0.1",
-    "ed25519-hd-key": "1.0.0",
+    "ed25519-hd-key": "^1.1.2",
     "lisk-elements": "^1.0.0-rc.0"
   }
 }

--- a/src/index.spec.ts
+++ b/src/index.spec.ts
@@ -37,7 +37,7 @@ describe('Main module', () => {
             signTransaction(hexSeed, path, unsignedTransaction);
             expect(prepareTransaction).toBeCalledWith(
                 Object.assign(unsignedTransaction, { senderPublicKey: publicKey.toString('hex')}),
-                [...key, ...publicKey]
+                Buffer.concat([key, publicKey])
             );
         });
     });


### PR DESCRIPTION
This tool was not working because of NACL version (same as https://github.com/alepop/ed25519-hd-key/issues/39)

I've also fixed the examples with a working one + add a NOTE about how we derive path for lisk wallets.